### PR TITLE
Fix #1: Reduce device selection UI prominence

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -174,16 +174,17 @@ main {
 }
 
 .device-selection {
-    margin-bottom: 20px;
+    margin-bottom: 10px; /* Reduced from 20px */
 }
 
 .device-selection select {
-    width: 100%;
-    padding: 10px;
-    background-color: rgba(44, 149, 200, 0.1);
+    width: 80%;
+    padding: 5px;
+    background-color: rgba(44, 149, 200, 0.05);
     border: 1px solid var(--primary-color);
     border-radius: 5px;
     color: var(--text-color);
+    font-size: 0.8em;
 }
 
 .controls {


### PR DESCRIPTION
Adjusted CSS to reduce the visual prominence and size of the device selection element as requested. Changes include:
- Reduced margin-bottom from 20px → 10px
- Shrank select width to 80%
- Decreased padding to 5px
- Lightened background opacity
- Smaller font size (0.8em)